### PR TITLE
Find source of bug and implemented a fix

### DIFF
--- a/WorkerView/src/components/Editor/MainEditor.vue
+++ b/WorkerView/src/components/Editor/MainEditor.vue
@@ -178,12 +178,19 @@ function canvasClicked(event) {
   var img = new Image();
   img.src = image.value;
 
+  // this is a check for a bug where the image width and height are 0 for some reason
+  // discard the click if this is the case and log it
+  if (img.width == 0 || img.height == 0) {
+    console.log("Image width or height = 0, value discarded")
+  }
+  else {
   // By taking the ratio between the relative coordinates and the canvas, we can map them to the image size.
   const x = (x_canv / rect.width) * img.width;
   const y = (y_canv / rect.height) * img.height;
 
   // The controller will redirect the click to the according tool.
   controller.onClick(x,y);
+  }
 }
 
 // This function handles the undo and redo keyboard events and delegates them to the controller.


### PR DESCRIPTION
The Source of this bug seemed to be that some browsers sometimes register the width and height of the image as 0 either during the first click or another click somewhere in between. Since we multiply the coords with the height and width when mapping them to the image, the height and width being 0 will result in the coords being 0,0 aswell and ending up in the upper left corner.

This was simply fixed by adding a check that discards the click any time an "impossible" image height or width value of 0 is read and logs this to the console. The  user might have to double click sometimes but at least the editor is usable again.