### PR TITLE
Story22: PhotoView Error Handling

### DIFF
--- a/PhotoView/src/components/Camera.vue
+++ b/PhotoView/src/components/Camera.vue
@@ -67,8 +67,6 @@ onMounted(() => {
 </script>
 
 <template>
-  <h2 class="header">PhotoView</h2>
-
   <!-- the main contianer contains the camera view-->
   <div class="main-container">
     <div class="video-mask">
@@ -105,11 +103,6 @@ video {
   align-items: center;
   overflow: hidden;
   justify-content: center;
-}
-
-.header {
-  padding: 0;
-  margin: 0;
 }
 
 </style>

--- a/PhotoView/src/components/Camera.vue
+++ b/PhotoView/src/components/Camera.vue
@@ -73,8 +73,9 @@ onMounted(() => {
   <div class="main-container">
     <div class="video-mask">
       <video v-if="isVideoVisible" id="webcam" ref="webcam" autoplay muted></video>
-      <p v-if="!isVideoVisible">Keine Kamera</p>
     </div>
+    <i v-if="!isVideoVisible" class="pi pi-eye-slash my-icon" style="font-size: 10rem;" ></i>
+    <p v-if="!isVideoVisible">Keine Kamera</p>
   </div>
 </template>
 

--- a/PhotoView/src/components/Camera.vue
+++ b/PhotoView/src/components/Camera.vue
@@ -2,12 +2,14 @@
 
 <script setup>
 import { ref, onMounted } from "vue";
+import { useToast } from 'primevue/usetoast';
 
 // original code from: https://codelabs.developers.google.com/codelabs/tensorflowjs-object-detection#6
 
 //references
 const video = ref(null);
 const isVideoVisible = ref(true);
+const toast = useToast();
 
 // The onMounted lifecycle hook is used to run an async function when the component is mounted.
 onMounted(() => {
@@ -64,6 +66,22 @@ onMounted(() => {
     })
   }
 });
+
+onMounted(() => {
+  // check if the website is opened with mobile or desktop
+  if(/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)) {
+    console.log('The website is opened with a "phone"');
+  } else {
+    console.log('The website is opened with a computer');
+
+    // add delay of 3 seconds
+    setTimeout(() => {
+      toast.add({ severity: 'warning', summary: 'Warnung', 
+      detail:'Willkommen auf unserer mobilen optimierten Seite! Bitte beachten Sie, dass die Benutzererfahrung auf einem Desktop-Computer möglicherweise nicht optimal ist. Wir empfehlen die Nutzung eines mobilen Geräts für das bestmögliche Surferlebnis', 
+      life: 10000 });
+    }, 3000);
+  }
+})
 </script>
 
 <template>

--- a/PhotoView/src/components/Camera.vue
+++ b/PhotoView/src/components/Camera.vue
@@ -7,6 +7,7 @@ import { ref, onMounted } from "vue";
 
 //references
 const video = ref(null);
+const isVideoVisible = ref(true);
 
 // The onMounted lifecycle hook is used to run an async function when the component is mounted.
 onMounted(() => {
@@ -56,6 +57,10 @@ onMounted(() => {
       navigator.mediaDevices.getUserMedia(constraints).then(function (stream) {
       video.srcObject = stream;
       })
+      .catch((error) => {
+        console.log('no camera')
+        isVideoVisible.value = false;
+      })
     })
   }
 });
@@ -67,7 +72,8 @@ onMounted(() => {
   <!-- the main contianer contains the camera view-->
   <div class="main-container">
     <div class="video-mask">
-      <video id="webcam" ref="webcam" autoplay muted></video>
+      <video v-if="isVideoVisible" id="webcam" ref="webcam" autoplay muted></video>
+      <p v-if="!isVideoVisible">Keine Kamera</p>
     </div>
   </div>
 </template>

--- a/PhotoView/src/components/MainPage.vue
+++ b/PhotoView/src/components/MainPage.vue
@@ -1,6 +1,7 @@
 <script setup>
 import Camera from "./Camera.vue"
 import Popup from "./Popup.vue"
+import Toast from 'primevue/toast';
 
 </script>
 
@@ -8,6 +9,7 @@ import Popup from "./Popup.vue"
     <h2 class="header">PhotoView</h2>
   <Camera/>
   <Popup/>
+  <Toast/>
 </template>
 
 <style scoped>

--- a/PhotoView/src/components/MainPage.vue
+++ b/PhotoView/src/components/MainPage.vue
@@ -5,6 +5,14 @@ import Popup from "./Popup.vue"
 </script>
 
 <template>
+    <h2 class="header">PhotoView</h2>
   <Camera/>
   <Popup/>
 </template>
+
+<style scoped>
+  .header {
+  padding: 0;
+  margin: 0;
+  }
+</style>

--- a/PhotoView/src/components/Popup.vue
+++ b/PhotoView/src/components/Popup.vue
@@ -10,6 +10,7 @@ import 'primeicons/primeicons.css'
 //references
 let image;
 const visible = ref(false);
+const isImageLoaded = ref(true);
 
 //! this function will be necessary in the future
 function downloadPicture() {
@@ -85,6 +86,12 @@ async function sendPicture() {
 // this loads the image into the Popup
 function loadImage() {
   let video = document.getElementById('webcam')
+
+  if(video == null) {
+    isImageLoaded.value = false;
+    return;
+  } 
+
   let canvas = document.createElement('canvas');
   canvas.width = video.videoWidth;
   canvas.height = video.videoHeight;
@@ -101,6 +108,7 @@ function loadImage() {
   image.onload = function() {
     let myImage = document.getElementById("my-image");
     myImage.src = image.src;
+    isImageLoaded.value = true;
     }
   }
 
@@ -125,6 +133,7 @@ function openGallery() {
     image.onload = function() {
       let myImage = document.getElementById("my-image");
       myImage.src = image.src;
+      isImageLoaded.value = true;
     }
   }
 
@@ -143,6 +152,7 @@ input.click();
   <Dialog v-model:visible="visible" header="Senden" :style="{ width: '25rem', maxHeight: '80vh', overflowY: 'auto' }">
   <div class="modal-body">
     <img id="my-image" src="" alt="" />
+    <p v-if="!isImageLoaded"> Kein Bild </p>
   </div>
   <div class="modal-footer">
     <ButtonGroup id="send-and-safe">  


### PR DESCRIPTION
- Displays text and icon when there is no camera
     * Sadly Primevue does not have a slashed camera icon
     * Therefore a slashed eye Icon is used instead
- You get warned by a toast, when you open the PhotoView on Desktop
- A text is displayed in the Popup, when there is no Image
     * This only works for the 'Bild erstellen'-button 
     * And not for the from Gallery-button