### PR TITLE
Issue118: gave the image from the editor a max-height

### DIFF
--- a/WorkerView/src/components/Editor/MainEditor.vue
+++ b/WorkerView/src/components/Editor/MainEditor.vue
@@ -294,6 +294,7 @@ function canvasBack(event){
 #zoom-outer {
   width: 70%;
   height: auto;
+  min-height: 70vh;
   background: #3a3838;
   overflow: hidden;
   margin: auto;
@@ -313,8 +314,8 @@ function canvasBack(event){
 }
 
 #canvas {
-  width: 100%;
-  height: auto;
+  max-width: 100%;
+  max-height: 100vh;
 }
 
 #clickListenerCanvas{


### PR DESCRIPTION
- Corresponding issue: https://github.com/APSE-System/Immerscale/issues/118
- Gave the image from the editor a max-height
- Also implemented padding if the image is very small

## How to Test
- Insert multiple images with different resolutions in the Workerview 
   * (Use the Photoview upload from gallery button)
- See if every image looks ok