### PR TITLE
Issue117: Measurement Tool is still selected even if undo

### DIFF
--- a/WorkerView/src/components/Editor/Logic/Controller.js
+++ b/WorkerView/src/components/Editor/Logic/Controller.js
@@ -11,6 +11,7 @@ class Controller{
 
     constructor(model){
         this._model = model;
+        document.addEventListener("deselectTool", () => {this._currentTool.deselect(); this._currentTool = null;})
     }
 
     addTool(tool){

--- a/WorkerView/src/components/Editor/Logic/Tools/LineLengthMeasurementTool.js
+++ b/WorkerView/src/components/Editor/Logic/Tools/LineLengthMeasurementTool.js
@@ -29,6 +29,12 @@ class LineLengthMeasurementTool extends MeasurementTool {
     }
 
     onClick(x, y) {
+        // This tool should not be usable if no reference is set
+        if(!LordImmerScaler._referenceSet){
+            document.dispatchEvent(new CustomEvent("deselectTool"));
+            return;
+        }
+
         // Checking how many points were already specified by the user and adding new commands accordingly.
         if (this._pointCount == 0 || this._pointCount == 2) {
             // The first command is simply adding a point to the user selected coordinates.
@@ -44,14 +50,6 @@ class LineLengthMeasurementTool extends MeasurementTool {
             this._model.do(new AddLineCommand(this, this._model, [[this._firstX, this._firstY], [this._secondX, this._secondY]], true, true, this.measureLength(), false));
             // The tool is finished after the second point is set, all points are reset.
             this.measurementCompleted();
-            // this causes a bug
-            // this._first = null;
-            // this._firstX = 0;
-            // this._firstY = 0;
-            // this._secondX = 0;
-            // this._secondY = 0;
-            // this._pointCount = 0;
-            // this._finished = true;
         }
     }
 

--- a/WorkerView/src/components/Editor/Logic/Tools/PolygonMeasurementTool.js
+++ b/WorkerView/src/components/Editor/Logic/Tools/PolygonMeasurementTool.js
@@ -28,7 +28,11 @@ class PolygonMeasurementTool extends MeasurementTool {
 
 
     onClick(x, y) {
-        //this._points.push([x,y]);
+        // This tool should not be usable if no reference is set
+        if(!LordImmerScaler._referenceSet){
+            document.dispatchEvent(new CustomEvent("deselectTool"));
+            return;
+        }
 
         // Checking how many points were already specified by the user and adding new commands accordingly.
         if (this._pointCount == 0) {


### PR DESCRIPTION
Quick fix for #117 :
- Each time a reference tool registers a click it first checks if there is already a reference set.
- If not, it dispaches an event which is handeled by the controller and automatically deselects itself.