### PR TITLE
point-komma: changed . to ,

### DIFF
--- a/WorkerView/src/components/Editor/CommandComponents/AddAreaComponent.vue
+++ b/WorkerView/src/components/Editor/CommandComponents/AddAreaComponent.vue
@@ -148,7 +148,8 @@ function clearPreview() {
     // Center the text horizontally and vertically
     const textWidth = ctx.measureText(value).width;
       
-    ctx.fillText(value, centerX - textWidth / 2, centerY + 10);
+    // draw the centered size with , instead of .
+    ctx.fillText(value.toString().replace(".", ","), centerX - textWidth / 2, centerY + 10);
   }
 </script>
 

--- a/WorkerView/src/components/Editor/CommandComponents/AddLabelComponent.vue
+++ b/WorkerView/src/components/Editor/CommandComponents/AddLabelComponent.vue
@@ -35,7 +35,8 @@ function displayLength(value, ctx, label) {
     
     value += " cm"
 
-    ctx.fillText(value, label.x - textWidth / 2, label.y + 30);
+    // draw the centered length with , instead of .
+    ctx.fillText(value.toString().replace(".", ","), label.x - textWidth / 2, label.y + 30);
 }
 
 </script>


### PR DESCRIPTION
- The size and area are now seperated with a , instead of a .
![grafik](https://github.com/APSE-System/Immerscale/assets/128397059/d914c438-0256-4937-8e05-6e0512d69e5d)
